### PR TITLE
Fix the default docker image used in the helm-chart

### DIFF
--- a/helm/appoptics-controller/values.yaml
+++ b/helm/appoptics-controller/values.yaml
@@ -6,7 +6,7 @@ namespace: default
 
 image:
   registry: docker.io
-  repository: appoptics/appoptics-controller-controller
+  repository: appoptics/appoptics-kubernetes-controller
   tag: "0.1"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
the actual docker image repo is https://hub.docker.com/r/appoptics/appoptics-kubernetes-controller/ 